### PR TITLE
ncam前增加一个\，这样就可以找到扩展的路径了。

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
             tlmSiblingOfDojo: false,
             packages: [{
                 name: "ncam",
-                location: location.pathname.replace(/\/[^/]+$/, '') + "ncam"
+                location: location.pathname.replace(/\/[^/]+$/, '') + "\/ncam"
             }]
         };
     </script>


### PR DESCRIPTION
may be the index.html is better to write like this:

 var dojoConfig = {
            parseOnLoad: false,
            async: true,
            tlmSiblingOfDojo: false,
            packages: [{
                name: "ncam",
                location: location.pathname.replace(/\/[^/]+$/, '') + "**\/ncam**"
            }]
        };